### PR TITLE
## NO-TICKET: Fix mining bedrock with pickaxe

### DIFF
--- a/modules/block-interactions/src/main/java/unnamed/mmo/blocks/ore/handler/OreBlockHandler.java
+++ b/modules/block-interactions/src/main/java/unnamed/mmo/blocks/ore/handler/OreBlockHandler.java
@@ -31,7 +31,7 @@ public class OreBlockHandler implements BlockHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(OreBlockHandler.class);
 
     //todo this should probably be configurable.
-    private static final Block REPLACEMENT_BLOCK = Block.BEDROCK;
+    public static final Block REPLACEMENT_BLOCK = Block.BEDROCK;
 
     private OreBlockHandler() {
         Check.stateCondition(instance != null, "There can only be one OreBlockHandler");

--- a/modules/block-interactions/src/main/java/unnamed/mmo/blocks/ore/item/PickaxeHandler.java
+++ b/modules/block-interactions/src/main/java/unnamed/mmo/blocks/ore/item/PickaxeHandler.java
@@ -4,6 +4,7 @@ import com.google.auto.service.AutoService;
 import com.mojang.serialization.Codec;
 import net.minestom.server.event.Event;
 import net.minestom.server.event.EventNode;
+import net.minestom.server.instance.block.Block;
 import net.minestom.server.utils.NamespaceID;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -11,6 +12,8 @@ import unnamed.mmo.blocks.ore.Ore;
 import unnamed.mmo.item.Item;
 import unnamed.mmo.item.ItemComponentHandler;
 import unnamed.mmo.player.event.PlayerLongDiggingStartEvent;
+
+import static unnamed.mmo.blocks.ore.handler.OreBlockHandler.REPLACEMENT_BLOCK;
 
 @AutoService(ItemComponentHandler.class)
 public class PickaxeHandler implements ItemComponentHandler<Pickaxe> {
@@ -43,7 +46,7 @@ public class PickaxeHandler implements ItemComponentHandler<Pickaxe> {
 
     private void handleLongDiggingStart(PlayerLongDiggingStartEvent event) {
         var ore = Ore.fromBlock(event.getBlock());
-        if (ore == null) return; // Did not dig a known ore block
+        if (ore == null || event.getBlock().compare(REPLACEMENT_BLOCK, Block.Comparator.STATE)) return;
 
         // Ensure they have a pickaxe in hand and get the pickaxe
         var item = Item.fromItemStack(event.getPlayer().getItemInMainHand());


### PR DESCRIPTION
[Problem]

Was able to mine bedrock with pickaxe

[Solution]

Test at PickaxeHandler that the block being mined is not bedrock

[Testing]

Verified that can no longer break bedrock, and also that no unintended error (messages) come up