### PR TITLE
## #43: Prevent players from swimming up waterfalls

### DIFF
--- a/modules/build.gradle.kts
+++ b/modules/build.gradle.kts
@@ -4,6 +4,8 @@ subprojects {
     apply(plugin = "java")
     apply(plugin = "net.ltgt.errorprone")
 
+    group = "net.hollowcube.libmmo"
+
     repositories {
         mavenCentral()
         maven(url = "https://jitpack.io")

--- a/modules/common/src/main/java/net/hollowcube/registry/MissingEntryException.java
+++ b/modules/common/src/main/java/net/hollowcube/registry/MissingEntryException.java
@@ -1,0 +1,22 @@
+package net.hollowcube.registry;
+
+import org.jetbrains.annotations.NotNull;
+
+public class MissingEntryException extends RuntimeException{
+    private final @NotNull Registry<?> registry;
+    private final @NotNull String key;
+
+    public MissingEntryException(@NotNull Registry<?> registry, @NotNull String key) {
+        super("Missing registry entry: " + key + " in " + registry + "!");
+        this.registry = registry;
+        this.key = key;
+    }
+
+    public @NotNull Registry<?> registry() {
+        return registry;
+    }
+
+    public @NotNull String key() {
+        return key;
+    }
+}

--- a/modules/common/src/main/java/net/hollowcube/registry/Registry.java
+++ b/modules/common/src/main/java/net/hollowcube/registry/Registry.java
@@ -164,7 +164,7 @@ public interface Registry<T extends Resource> {
 
     default @NotNull T required(String namespace) {
         T result = get(namespace);
-        Check.notNull(result, "Missing required registry entry: " + namespace);
+        if (result == null) throw new MissingEntryException(this, namespace);
         return result;
     }
 

--- a/modules/common/src/test/java/net/hollowcube/registry/TestMissingEntry.java
+++ b/modules/common/src/test/java/net/hollowcube/registry/TestMissingEntry.java
@@ -1,0 +1,17 @@
+package net.hollowcube.registry;
+
+import com.google.gson.JsonParser;
+import com.mojang.serialization.JsonOps;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class TestMissingEntry {
+
+    @Test
+    public void testMissingRegistryEntry() {
+        var json = JsonParser.parseString("{\"type\": \"missing\"}");
+        assertThrows(MissingEntryException.class, () -> JsonOps.INSTANCE.withDecoder(TestResource.CODEC).apply(json));
+    }
+
+}

--- a/modules/common/src/test/java/net/hollowcube/registry/TestResource.java
+++ b/modules/common/src/test/java/net/hollowcube/registry/TestResource.java
@@ -1,0 +1,26 @@
+package net.hollowcube.registry;
+
+import com.mojang.serialization.Codec;
+import net.minestom.server.utils.NamespaceID;
+import org.jetbrains.annotations.NotNull;
+
+public interface TestResource extends Resource {
+
+    Codec<TestResource> CODEC = Factory.CODEC.dispatch(Factory::from, Factory::codec);
+
+    abstract class Factory extends ResourceFactory<TestResource> {
+        static Registry<Factory> REGISTRY = Registry.service("test_resource", Factory.class);
+        static Registry.Index<Class<?>, Factory> TYPE_REGISTRY = REGISTRY.index(Factory::type);
+
+        static Codec<Factory> CODEC = Codec.STRING.xmap(ns -> REGISTRY.required(ns), Factory::name);
+
+        public Factory(NamespaceID namespace, Class<? extends TestResource> type, Codec<? extends TestResource> codec) {
+            super(namespace, type, codec);
+        }
+
+        public static @NotNull Factory from(@NotNull TestResource resource) {
+            return TYPE_REGISTRY.get(resource.getClass());
+        }
+    }
+
+}

--- a/modules/development/src/main/java/net/hollowcube/server/dev/Main.java
+++ b/modules/development/src/main/java/net/hollowcube/server/dev/Main.java
@@ -92,6 +92,26 @@ public class Main {
             event.getSpawnInstance().setBlock(11, 47, 5, Block.WATER);
             event.getSpawnInstance().setBlock(11, 48, 5, Block.WATER);
 
+            event.getSpawnInstance().setBlock(10, 40, 5, Block.BUBBLE_COLUMN);
+            event.getSpawnInstance().setBlock(10, 41, 5, Block.BUBBLE_COLUMN);
+            event.getSpawnInstance().setBlock(10, 42, 5, Block.BUBBLE_COLUMN);
+            event.getSpawnInstance().setBlock(10, 43, 5, Block.BUBBLE_COLUMN);
+            event.getSpawnInstance().setBlock(10, 44, 5, Block.BUBBLE_COLUMN);
+            event.getSpawnInstance().setBlock(10, 45, 5, Block.BUBBLE_COLUMN);
+            event.getSpawnInstance().setBlock(10, 46, 5, Block.BUBBLE_COLUMN);
+            event.getSpawnInstance().setBlock(10, 47, 5, Block.BUBBLE_COLUMN);
+            event.getSpawnInstance().setBlock(10, 48, 5, Block.BUBBLE_COLUMN);
+
+            event.getSpawnInstance().setBlock(11, 40, 5, Block.WATER);
+            event.getSpawnInstance().setBlock(11, 41, 5, Block.WATER);
+            event.getSpawnInstance().setBlock(11, 42, 5, Block.WATER);
+            event.getSpawnInstance().setBlock(11, 43, 5, Block.WATER);
+            event.getSpawnInstance().setBlock(11, 44, 5, Block.WATER);
+            event.getSpawnInstance().setBlock(11, 45, 5, Block.WATER);
+            event.getSpawnInstance().setBlock(11, 46, 5, Block.WATER);
+            event.getSpawnInstance().setBlock(11, 47, 5, Block.WATER);
+            event.getSpawnInstance().setBlock(11, 48, 5, Block.WATER);
+
             //todo this needs to be done elsewhere
             player.addEffect(new Potion(PotionEffect.MINING_FATIGUE, (byte) -1, Short.MAX_VALUE, (byte) 0x0));
 

--- a/modules/development/src/main/java/net/hollowcube/server/dev/Main.java
+++ b/modules/development/src/main/java/net/hollowcube/server/dev/Main.java
@@ -69,9 +69,28 @@ public class Main {
             player.setAllowFlying(true);
 
             // Testing
-            event.getSpawnInstance().setBlock(5, 43, 5, Ore.fromNamespaceId("unnamed:gold_ore").asBlock());
-            event.getSpawnInstance().setBlock(4, 43, 5, Ore.fromNamespaceId("unnamed:diamond_ore").asBlock());
-            player.getInventory().addItemStack(Item.fromNamespaceId("unnamed:diamond_pickaxe").asItemStack());
+            event.getSpawnInstance().setBlock(5, 43, 5, Ore.fromNamespaceId("starlight:gold_ore").asBlock());
+            event.getSpawnInstance().setBlock(4, 43, 5, Ore.fromNamespaceId("starlight:diamond_ore").asBlock());
+
+            event.getSpawnInstance().setBlock(10, 40, 5, Block.BUBBLE_COLUMN);
+            event.getSpawnInstance().setBlock(10, 41, 5, Block.BUBBLE_COLUMN);
+            event.getSpawnInstance().setBlock(10, 42, 5, Block.BUBBLE_COLUMN);
+            event.getSpawnInstance().setBlock(10, 43, 5, Block.BUBBLE_COLUMN);
+            event.getSpawnInstance().setBlock(10, 44, 5, Block.BUBBLE_COLUMN);
+            event.getSpawnInstance().setBlock(10, 45, 5, Block.BUBBLE_COLUMN);
+            event.getSpawnInstance().setBlock(10, 46, 5, Block.BUBBLE_COLUMN);
+            event.getSpawnInstance().setBlock(10, 47, 5, Block.BUBBLE_COLUMN);
+            event.getSpawnInstance().setBlock(10, 48, 5, Block.BUBBLE_COLUMN);
+
+            event.getSpawnInstance().setBlock(11, 40, 5, Block.WATER);
+            event.getSpawnInstance().setBlock(11, 41, 5, Block.WATER);
+            event.getSpawnInstance().setBlock(11, 42, 5, Block.WATER);
+            event.getSpawnInstance().setBlock(11, 43, 5, Block.WATER);
+            event.getSpawnInstance().setBlock(11, 44, 5, Block.WATER);
+            event.getSpawnInstance().setBlock(11, 45, 5, Block.WATER);
+            event.getSpawnInstance().setBlock(11, 46, 5, Block.WATER);
+            event.getSpawnInstance().setBlock(11, 47, 5, Block.WATER);
+            event.getSpawnInstance().setBlock(11, 48, 5, Block.WATER);
 
             //todo this needs to be done elsewhere
             player.addEffect(new Potion(PotionEffect.MINING_FATIGUE, (byte) -1, Short.MAX_VALUE, (byte) 0x0));

--- a/modules/item/src/main/java/net/hollowcube/item/ItemComponentHandler.java
+++ b/modules/item/src/main/java/net/hollowcube/item/ItemComponentHandler.java
@@ -14,7 +14,7 @@ public interface ItemComponentHandler<C extends ItemComponent> extends Resource 
 
     // Cannot be a method ref because REGISTRY may be mid-initialization when this is initialized.
     @SuppressWarnings("Convert2MethodRef")
-    Codec<ItemComponentHandler<?>> CODEC = Codec.STRING.xmap(namespace -> ItemComponentRegistry.REGISTRY.get(namespace), ItemComponentHandler::name);
+    Codec<ItemComponentHandler<?>> CODEC = Codec.STRING.xmap(namespace -> ItemComponentRegistry.REGISTRY.required(namespace), ItemComponentHandler::name);
 
 
     // Descriptors

--- a/modules/item/src/main/java/net/hollowcube/item/ItemManager.java
+++ b/modules/item/src/main/java/net/hollowcube/item/ItemManager.java
@@ -17,7 +17,7 @@ public class ItemManager implements Facet {
 
     @Override
     public void hook(@NotNull ServerWrapper server) {
-        EventNode<Event> eventNode = EventNode.all("unnamed:item/facet");
+        EventNode<Event> eventNode = EventNode.all("starlight:item/facet");
         server.addEventNode(eventNode);
 
         // Component handlers

--- a/modules/item/src/main/java/net/hollowcube/item/impl/RarityHandler.java
+++ b/modules/item/src/main/java/net/hollowcube/item/impl/RarityHandler.java
@@ -13,7 +13,7 @@ public class RarityHandler implements ItemComponentHandler<Rarity> {
 
     @Override
     public @NotNull NamespaceID namespace() {
-        return NamespaceID.from("unnamed:rarity");
+        return NamespaceID.from("starlight:rarity");
     }
 
     @Override

--- a/modules/loot-table/src/main/java/net/hollowcube/loot/LootEntry.java
+++ b/modules/loot-table/src/main/java/net/hollowcube/loot/LootEntry.java
@@ -24,7 +24,7 @@ public interface LootEntry<T> {
         static Registry<Factory> REGISTRY = Registry.service("loot_entries", Factory.class);
         static Registry.Index<Class<?>, Factory> TYPE_REGISTRY = REGISTRY.index(Factory::type);
 
-        static Codec<Factory> CODEC = Codec.STRING.xmap(ns -> REGISTRY.get(ns), Factory::name);
+        static Codec<Factory> CODEC = Codec.STRING.xmap(ns -> REGISTRY.required(ns), Factory::name);
 
         public Factory(NamespaceID namespace, Class<? extends LootEntry<?>> type, Codec<? extends LootEntry<?>> codec) {
             super(namespace, type, codec);

--- a/modules/loot-table/src/main/java/net/hollowcube/loot/LootModifier.java
+++ b/modules/loot-table/src/main/java/net/hollowcube/loot/LootModifier.java
@@ -20,7 +20,7 @@ public interface LootModifier {
         static Registry<Factory> REGISTRY = Registry.service("loot_modifiers", LootModifier.Factory.class);
         static Registry.Index<Class<?>, Factory> TYPE_REGISTRY = REGISTRY.index(Factory::type);
 
-        static Codec<Factory> CODEC = Codec.STRING.xmap(ns -> REGISTRY.get(ns), Factory::name);
+        static Codec<Factory> CODEC = Codec.STRING.xmap(ns -> REGISTRY.required(ns), Factory::name);
 
         public Factory(NamespaceID namespace, Class<? extends LootModifier> type, Codec<? extends LootModifier> codec) {
             super(namespace, type, codec);

--- a/modules/loot-table/src/main/java/net/hollowcube/loot/LootPredicate.java
+++ b/modules/loot-table/src/main/java/net/hollowcube/loot/LootPredicate.java
@@ -25,7 +25,7 @@ public interface LootPredicate {
         static Registry<Factory> REGISTRY = Registry.service("loot_predicates", LootPredicate.Factory.class);
         static Registry.Index<Class<?>, Factory> TYPE_REGISTRY = REGISTRY.index(Factory::type);
 
-        public static final Codec<Factory> CODEC = Codec.STRING.xmap(ns -> REGISTRY.get(ns), Factory::name);
+        public static final Codec<Factory> CODEC = Codec.STRING.xmap(ns -> REGISTRY.required(ns), Factory::name);
 
         public Factory(NamespaceID namespace, Class<? extends LootPredicate> type, Codec<? extends LootPredicate> codec) {
             super(namespace, type, codec);

--- a/modules/player/src/main/java/net/hollowcube/damage/weapon/WeaponHandler.java
+++ b/modules/player/src/main/java/net/hollowcube/damage/weapon/WeaponHandler.java
@@ -9,7 +9,7 @@ import net.hollowcube.item.ItemComponentHandler;
 
 public class WeaponHandler implements ItemComponentHandler<Weapon> {
 
-    private final EventNode<Event> eventNode = EventNode.all("unnamed:weapon/item_component_handler");
+    private final EventNode<Event> eventNode = EventNode.all("starlight:weapon/item_component_handler");
 
     public WeaponHandler() {
 
@@ -17,7 +17,7 @@ public class WeaponHandler implements ItemComponentHandler<Weapon> {
 
     @Override
     public @NotNull NamespaceID namespace() {
-        return NamespaceID.from("unnamed:weapon");
+        return NamespaceID.from("starlight:weapon");
     }
 
     @Override

--- a/modules/player/src/main/java/net/hollowcube/player/PlayerImpl.java
+++ b/modules/player/src/main/java/net/hollowcube/player/PlayerImpl.java
@@ -3,10 +3,10 @@ package net.hollowcube.player;
 import net.hollowcube.modifiers.ModifierList;
 import net.hollowcube.modifiers.ModifierOperation;
 import net.hollowcube.modifiers.ModifierType;
-import net.hollowcube.player.event.PlayerBubbleColumnSinkEvent;
 import net.hollowcube.player.event.PlayerLongDiggingStartEvent;
 import net.minestom.server.MinecraftServer;
 import net.minestom.server.coordinate.Point;
+import net.minestom.server.coordinate.Pos;
 import net.minestom.server.entity.Player;
 import net.minestom.server.event.player.PlayerPacketEvent;
 import net.minestom.server.instance.Instance;
@@ -105,33 +105,26 @@ public class PlayerImpl extends Player {
     }
 
     private void handlePositionPacket(ClientPlayerPositionPacket packet) {
+        Pos playerPos = this.getPosition();
+        Block blockAtPlayerPos = this.getInstance().getBlock(playerPos);
+
         if (packet.onGround()) {
 
         }
         else {
-            if (this.getInstance().getBlock(this.getPosition()) == Block.BUBBLE_COLUMN) {
-                //TODO: I think we want to make this part of a whole PlayerInWaterHandler or something, and on top of that,
-                // we would have to make a BlockComponentHandler or something to encapsulate it. I wonder if @Matt has a
-                // suggestion on this.
-
-                // PlayerBubbleColumnSinkEvent playerBubbleColumnSinkEvent = new PlayerBubbleColumnSinkEvent(this, this.getFood());
-                // MinecraftServer.getGlobalEventHandler().call(playerBubbleColumnSinkEvent);
-
+            if (blockAtPlayerPos == Block.BUBBLE_COLUMN) {
                 if (!this.wasLastSeenInBubbleColumn) {
                     this.wasLastSeenInBubbleColumn = true;
                     this.bubbleColumnSinkEnergyLevel = this.getFood();
-                    //TODO: This does not work lol it is not implemented in minestom to get rid of the player's
-                    // ability to sprint when they have hunger below 7
                     this.setFood(6);
                 }
             }
-            else if (this.wasLastSeenInBubbleColumn) {
-                if (this.getInstance().getBlock(this.getPosition()) != Block.BUBBLE_COLUMN) {
-                    this.wasLastSeenInBubbleColumn = false;
-                    this.setFood(this.bubbleColumnSinkEnergyLevel);
-                    this.bubbleColumnSinkEnergyLevel = -1;
-                }
-            }
+        }
+
+        if ((this.wasLastSeenInBubbleColumn) && (blockAtPlayerPos != Block.BUBBLE_COLUMN)) {
+            this.wasLastSeenInBubbleColumn = false;
+            this.setFood(this.bubbleColumnSinkEnergyLevel);
+            this.bubbleColumnSinkEnergyLevel = -1;
         }
     }
 

--- a/modules/player/src/main/java/net/hollowcube/player/event/PlayerBubbleColumnSinkEvent.java
+++ b/modules/player/src/main/java/net/hollowcube/player/event/PlayerBubbleColumnSinkEvent.java
@@ -1,0 +1,37 @@
+package net.hollowcube.player.event;
+
+import net.minestom.server.entity.Player;
+import net.minestom.server.event.trait.PlayerInstanceEvent;
+import net.minestom.server.instance.block.Block;
+import org.jetbrains.annotations.NotNull;
+
+public class PlayerBubbleColumnSinkEvent implements PlayerInstanceEvent {
+    private final Player player;
+    private final int energyLevel;
+
+    public PlayerBubbleColumnSinkEvent(Player player, int energyLevel) {
+        this.player = player;
+        this.energyLevel = energyLevel;
+    }
+
+    @Override
+    public @NotNull Player getPlayer() {
+        return player;
+    }
+
+    public int getEnergyLevel() {
+        return energyLevel;
+    }
+
+    public void cancelPlayerSwimming() {
+        if (player.getInstance().getBlock(player.getPosition()) == Block.BUBBLE_COLUMN) {
+            player.setFood(6);
+        }
+    }
+
+    public void restorePlayerEnergy() {
+        if (player.getInstance().getBlock(player.getPosition()) != Block.BUBBLE_COLUMN) {
+            player.setFood(energyLevel);
+        }
+    }
+}


### PR DESCRIPTION
[Problem]

Players can swim up waterfalls in areas where we want waterfalls as decoration but also need to restrict access.

[Solution]

Well there is none so far, since we tested and setting a player's hunger to 6 or lower does not work, since it is not implemented in Minestom to stop players from swimming or sprinting in this state.

Also added some comments about potential structuring of handling these types of events when we have a solution.