### PR TITLE
No Issue: Fix "Unnamed" to "Starlight" in line with name change

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -28,7 +28,7 @@ jobs:
           save-maven-dependencies-cache: true
           # Ignore some of the paths when caching Maven Local repository
           maven-local-ignore-paths: |
-            unnamed/mmo/
+            starlight/mmo/
       - name: Build
         run: ./gradlew classes testClasses
       - name: Run tests

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -1,2 +1,2 @@
-# Unnamed MMO
+# Starlight MMO
 

--- a/modules/block-interactions/src/main/java/net/hollowcube/blocks/ore/handler/OreBlockHandler.java
+++ b/modules/block-interactions/src/main/java/net/hollowcube/blocks/ore/handler/OreBlockHandler.java
@@ -141,7 +141,7 @@ public class OreBlockHandler implements BlockHandler {
 
     @Override
     public @NotNull NamespaceID getNamespaceId() {
-        return NamespaceID.from("unnamed:ore");
+        return NamespaceID.from("starlight:ore");
     }
 
     @Override

--- a/modules/block-interactions/src/main/java/net/hollowcube/blocks/ore/quest/MineOreObjective.java
+++ b/modules/block-interactions/src/main/java/net/hollowcube/blocks/ore/quest/MineOreObjective.java
@@ -64,7 +64,7 @@ public record MineOreObjective(
     @AutoService(Objective.Factory.class)
     public static class Factory extends Objective.Factory {
         public Factory() {
-            super(NamespaceID.from("unnamed:mine_ore"), MineOreObjective.class, MineOreObjective.CODEC);
+            super(NamespaceID.from("starlight:mine_ore"), MineOreObjective.class, MineOreObjective.CODEC);
         }
     }
 }

--- a/modules/chat/README.md
+++ b/modules/chat/README.md
@@ -1,4 +1,4 @@
 ## Chat
 
-General chat module for unnamed mmo.
+General chat module for starlight mmo.
 

--- a/modules/common/src/main/java/net/hollowcube/Env.java
+++ b/modules/common/src/main/java/net/hollowcube/Env.java
@@ -13,7 +13,7 @@ public class Env {
      * It should be used to check cases which are fine during development but are a fatal problem in production. For
      * example, if a registry is empty for any reason in production the server should not be allowed to start.
      */
-    public static final Boolean STRICT_MODE = Boolean.valueOf(System.getProperty("unnamed.strict", "false"));
+    public static final Boolean STRICT_MODE = Boolean.valueOf(System.getProperty("starlight.strict", "false"));
 
 
     private static final Logger STRICT_LOGGER = LoggerFactory.getLogger("STRICT");

--- a/modules/common/src/main/java/net/hollowcube/data/number/ConstantNumberProvider.java
+++ b/modules/common/src/main/java/net/hollowcube/data/number/ConstantNumberProvider.java
@@ -32,7 +32,7 @@ record ConstantNumberProvider(
     public static final class Factory extends NumberProvider.Factory {
         public Factory() {
             super(
-                    NamespaceID.from("unnamed:constant"),
+                    NamespaceID.from("starlight:constant"),
                     ConstantNumberProvider.class,
                     ConstantNumberProvider.CODEC
             );

--- a/modules/common/src/main/java/net/hollowcube/registry/Resource.java
+++ b/modules/common/src/main/java/net/hollowcube/registry/Resource.java
@@ -44,7 +44,7 @@ public interface Resource extends Keyed {
     }
 
 
-    Path DATA_PATH = Path.of(System.getProperty("unnamed.data.dir", "data"));
+    Path DATA_PATH = Path.of(System.getProperty("starlight.data.dir", "data"));
 
     /**
      * Attempts to load a resource file with the following priorities

--- a/modules/development/src/main/java/net/hollowcube/server/dev/Main.java
+++ b/modules/development/src/main/java/net/hollowcube/server/dev/Main.java
@@ -75,7 +75,7 @@ public class Main {
             player.addEffect(new Potion(PotionEffect.MINING_FATIGUE, (byte) -1, Short.MAX_VALUE, (byte) 0x0));
 
             //todo a command for this
-            player.getInventory().addItemStack(DebugToolManager.createTool("unnamed:hello"));
+            player.getInventory().addItemStack(DebugToolManager.createTool("starlight:hello"));
         });
 
         BaseCommandRegister.registerCommands(); //todo this should be in a facet?

--- a/modules/development/src/main/java/net/hollowcube/server/dev/command/ModifierCommand.java
+++ b/modules/development/src/main/java/net/hollowcube/server/dev/command/ModifierCommand.java
@@ -124,7 +124,7 @@ public class ModifierCommand extends Command {
         if(player.getDisplayName() != null) {
             sender.sendMessage(player.getDisplayName().append(Component.text("'s Modifiers:")));
         } else {
-            sender.sendMessage((Component.text(player.getUsername() + "'s Modifiers:")));
+            sender.sendMessage(Component.text(player.getUsername() + "'s Modifiers:"));
         }
 
         for (var entry : player.getCurrentModifierValues().entrySet()) {

--- a/modules/development/src/main/resources/data/quest.json
+++ b/modules/development/src/main/resources/data/quest.json
@@ -1,17 +1,17 @@
 [
   {
-    "namespace": "unnamed:test_1",
+    "namespace": "starlight:test_1",
     "objective": {
-      "type": "unnamed:sequence",
+      "type": "starlight:sequence",
       "children": [
         {
-          "type": "unnamed:mine_ore",
-          "ore": "unnamed:gold_ore",
+          "type": "starlight:mine_ore",
+          "ore": "starlight:gold_ore",
           "count": 3
         },
         {
-          "type": "unnamed:mine_ore",
-          "ore": "unnamed:diamond_ore",
+          "type": "starlight:mine_ore",
+          "ore": "starlight:diamond_ore",
           "count": 2
         }
       ]

--- a/modules/item/README.md
+++ b/modules/item/README.md
@@ -20,22 +20,22 @@ Items are loaded from a JSON data file, the format is described below
     "components": [
       {
         // Component ID
-        "type": "unnamed:my_component",
+        "type": "starlight:my_component",
         // All other values are determined by the component requirements.
         // See the section below on implementing components. A few samples are below
       },
       {
-        "type": "unnamed:fuel",
+        "type": "starlight:fuel",
         "burn_time": "200"
       },
       {
-        "type": "unnamed:sword",
+        "type": "starlight:sword",
         "cooldown": 5,
         "damage_type": "heavy",
         "base_damage": 25
       },
       {
-        "type": "unnamed:rarity",
+        "type": "starlight:rarity",
         "value": "legendary"
       }
     ],

--- a/modules/item/src/main/java/net/hollowcube/item/ItemImpl.java
+++ b/modules/item/src/main/java/net/hollowcube/item/ItemImpl.java
@@ -135,7 +135,7 @@ public record ItemImpl(
 
         @Override
         public @NotNull NamespaceID namespace() {
-            return NamespaceID.from("unnamed", "emptyitem");
+            return NamespaceID.from("starlight", "emptyitem");
         }
 
         @Override

--- a/modules/item/src/main/java/net/hollowcube/item/entity/OwnedItemEntity.java
+++ b/modules/item/src/main/java/net/hollowcube/item/entity/OwnedItemEntity.java
@@ -34,7 +34,7 @@ public class OwnedItemEntity extends ItemEntity {
     public static class Handler implements Facet {
         @Override
         public void hook(@NotNull ServerWrapper server) {
-            var eventNode = EventNode.all("unnamed:item_entity/handler");
+            var eventNode = EventNode.all("starlight:item_entity/handler");
             eventNode.addListener(PickupItemEvent.class, this::handlePickup);
             eventNode.addListener(EntityItemMergeEvent.class, this::handleMerge);
             server.addEventNode(eventNode);

--- a/modules/item/src/main/java/net/hollowcube/item/loot/ItemDistributor.java
+++ b/modules/item/src/main/java/net/hollowcube/item/loot/ItemDistributor.java
@@ -22,7 +22,7 @@ public class ItemDistributor implements LootResult.DefaultDistributor<Item> {
 
     @Override
     public @NotNull NamespaceID namespace() {
-        return NamespaceID.from("unnamed:item");
+        return NamespaceID.from("starlight:item");
     }
 
     @Override

--- a/modules/item/src/main/java/net/hollowcube/item/loot/ItemEntry.java
+++ b/modules/item/src/main/java/net/hollowcube/item/loot/ItemEntry.java
@@ -33,7 +33,7 @@ public record ItemEntry(
     public static class Factory extends LootEntry.Factory {
         public Factory() {
             super(
-                    NamespaceID.from("unnamed:item"),
+                    NamespaceID.from("starlight:item"),
                     ItemEntry.class,
                     ItemEntry.CODEC
             );

--- a/modules/item/src/test/java/net/hollowcube/item/TestItemRegistry.java
+++ b/modules/item/src/test/java/net/hollowcube/item/TestItemRegistry.java
@@ -7,7 +7,7 @@ import static com.google.common.truth.Truth.assertThat;
 
 public class TestItemRegistry {
     static {
-        System.setProperty("unnamed.data.dir", "src/test/resources");
+        System.setProperty("starlight.data.dir", "src/test/resources");
     }
 
     @Test

--- a/modules/quest/src/main/java/net/hollowcube/quest/QuestFacet.java
+++ b/modules/quest/src/main/java/net/hollowcube/quest/QuestFacet.java
@@ -56,8 +56,8 @@ public class QuestFacet implements Facet {
                     managers.put(player, manager);
                     event.getPlayer().sendMessage("Quest data loaded " + data);
 
-                    if (manager.getState("unnamed:test_1") == QuestState.NOT_STARTED) {
-                        manager.startQuest("unnamed:test_1");
+                    if (manager.getState("starlight:test_1") == QuestState.NOT_STARTED) {
+                        manager.startQuest("starlight:test_1");
                     }
                 }).exceptionally(FutureUtil::handleException);
     }

--- a/modules/quest/src/main/java/net/hollowcube/quest/objective/ParallelObjective.java
+++ b/modules/quest/src/main/java/net/hollowcube/quest/objective/ParallelObjective.java
@@ -73,7 +73,7 @@ public record ParallelObjective(List<Objective> children) implements Objective {
     @AutoService(Objective.Factory.class)
     public static class Factory extends Objective.Factory {
         public Factory() {
-            super(NamespaceID.from("unnamed:parallel"), ParallelObjective.class, ParallelObjective.CODEC);
+            super(NamespaceID.from("starlight:parallel"), ParallelObjective.class, ParallelObjective.CODEC);
         }
     }
 }

--- a/modules/quest/src/main/java/net/hollowcube/quest/objective/SequenceObjective.java
+++ b/modules/quest/src/main/java/net/hollowcube/quest/objective/SequenceObjective.java
@@ -66,7 +66,7 @@ public record SequenceObjective(List<Objective> children) implements Objective {
     @AutoService(Objective.Factory.class)
     public static class Factory extends Objective.Factory {
         public Factory() {
-            super(NamespaceID.from("unnamed:sequence"), SequenceObjective.class, SequenceObjective.CODEC);
+            super(NamespaceID.from("starlight:sequence"), SequenceObjective.class, SequenceObjective.CODEC);
         }
     }
 }


### PR DESCRIPTION
[Problem]

We had a lot of code references to unnamed where they should be starlight. This was also causing the test server to crash when mining blocks and the debug stick to not appear in player inventory.

[Solution]

Change all instances of "unnamed" to "starlight"

[Testing]

Tested and verified that debug stick shows up and can mine the test ores at spawn. No errors or warnings when starting up and joining server, and interacting with environment.